### PR TITLE
Add missing : in the logs

### DIFF
--- a/src/main/resources/data/fallback_log4j_config.xml
+++ b/src/main/resources/data/fallback_log4j_config.xml
@@ -6,9 +6,9 @@
 		<!--	System out	-->
 		<Console name="SysOut" target="SYSTEM_OUT">
 			<PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-true}">
+				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue}: %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-true}">
 					<!-- Dont show the logger name for minecraft classes-->
-					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(Minecraft)}{cyan} %highlight{%msg{nolookups}%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue}: %style{(Minecraft)}{cyan} %highlight{%msg{nolookups}%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
 				</LoggerNamePatternSelector>
 			</PatternLayout>
 		</Console>
@@ -16,9 +16,9 @@
 		<!--	Vanilla server gui	-->
 		<Queue name="ServerGuiConsole" ignoreExceptions="true">
 			<PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level] (%logger{1}) %msg{nolookups}%n">
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level]: (%logger{1}) %msg{nolookups}%n">
 					<!-- Dont show the logger name for minecraft classes-->
-					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss} %level] %msg{nolookups}%n"/>
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss} %level]: %msg{nolookups}%n"/>
 				</LoggerNamePatternSelector>
 			</PatternLayout>
 		</Queue>
@@ -26,9 +26,9 @@
 		<!--	latest.log same as vanilla	-->
 		<RollingRandomAccessFile name="LatestFile" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
 			<PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level] (%logger{1}) %msg{nolookups}%n">
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level]: (%logger{1}) %msg{nolookups}%n">
 					<!-- Dont show the logger name for minecraft classes-->
-					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss}] [%t/%level] (Minecraft) %msg{nolookups}%n"/>
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss}] [%t/%level]: (Minecraft) %msg{nolookups}%n"/>
 				</LoggerNamePatternSelector>
 			</PatternLayout>
 			<Policies>
@@ -39,7 +39,7 @@
 
 		<!--	Debug log file	-->
 		<RollingRandomAccessFile name="DebugFile" fileName="logs/debug.log" filePattern="logs/debug-%i.log.gz">
-			<PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] (%logger) %msg{nolookups}%n" />
+			<PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: (%logger) %msg{nolookups}%n" />
 
 			<!--	Keep 5 files max	-->
 			<DefaultRolloverStrategy max="5" fileIndex="min"/>


### PR DESCRIPTION
this PR simply add missing : which are present in the vanilla format to fix the log hosts like https://mclo.gs from not recognizing the log properly
![image](https://github.com/Julienraptor01/better_log4j_config/assets/49841713/34f0aedb-473b-4776-beac-7790b9b08648)

